### PR TITLE
feat: add Migaku browser extension compatibility for exam reading

### DIFF
--- a/apps/web/app/(dashboard)/student/exam/[examId]/page.tsx
+++ b/apps/web/app/(dashboard)/student/exam/[examId]/page.tsx
@@ -210,6 +210,15 @@ function ExamPageContent() {
     isUserSelecting,
   ])
 
+  // Migaku 익스텐션 SPA 호환: 질문 변경 시 URL hash 업데이트
+  // hashchange 이벤트를 통해 Migaku가 새 페이지로 인식하고 re-scan
+  useEffect(() => {
+    const questionIndex = modules[currentModuleIndex]?.currentQuestionIndex
+    if (questionIndex !== undefined) {
+      window.location.hash = `q-${questionIndex}`
+    }
+  }, [modules[currentModuleIndex]?.currentQuestionIndex, currentModuleIndex])
+
   // Handle exam start
   const handleStartExam = async () => {
     await startExam()

--- a/apps/web/components/exam/question-display.tsx
+++ b/apps/web/components/exam/question-display.tsx
@@ -1904,7 +1904,7 @@ export function QuestionDisplay({
                 if (!isHtml) {
                   // Markdown path (unchanged)
                   return (
-                    <div ref={questionContentRef}>
+                    <div key={localQuestion.id} ref={questionContentRef}>
                       <HighlightedTextRendererMemo
                         text={localQuestion.question_text}
                         highlights={highlights}
@@ -1937,7 +1937,7 @@ export function QuestionDisplay({
                         {renderHtmlContent(prefaceHtml)}
                       </div>
                     )}
-                    <div ref={questionContentRef}>
+                    <div key={localQuestion.id} ref={questionContentRef}>
                       <HighlightedTextRendererMemo
                         text={passageHtml}
                         highlights={highlights}


### PR DESCRIPTION
- Add key={localQuestion.id} to text content divs in QuestionDisplay so React fully remounts DOM nodes on question change
- Add URL hash update useEffect in exam page so Migaku detects question navigation as a new page and re-scans text overlays